### PR TITLE
Merged r15839 from trunk to 3.3-stable (#23835)

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -997,6 +997,7 @@ bg:
   label_field_format_enumeration: Списък ключ/стойност
   label_default_values_for_new_users: Стойности по подразбиране за нови потребители
   label_relations: Релации
+  label_new_project_issue_tab_enabled: Показване на меню-елемент "Нова задача"
   label_new_object_tab_enabled: Показване на изпадащ списък за меню-елемент "+"
 
   button_login: Вход
@@ -1193,6 +1194,5 @@ bg:
   description_date_from: Въведете начална дата
   description_date_to: Въведете крайна дата
   text_repository_identifier_info: 'Позволени са малки букви (a-z), цифри, тирета и _.<br />Промяна след създаването му не е възможна.'
-  label_new_project_issue_tab_enabled: Показване на меню-елемент "Нова задача"
   error_no_projects_with_tracker_allowed_for_new_issue: There are no projects with trackers
     for which you can create an issue


### PR DESCRIPTION
Bulgarian "label_new_project_issue_tab_enabled" translation line change.

git-svn-id: http://svn.redmine.org/redmine/branches/3.3-stable@15842 e93f8b46-1217-0410-a6f0-8f06a7374b81